### PR TITLE
SOD-169 attribute to dev null output

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,3 +2,4 @@ default['metric_maker']['root'] = '/opt/metric_maker'
 default['metric_maker']['region_override'] = '' # only define if you do not want this to be sorted out through ec2 meta-data
 default['metric_maker']['interval'] = 1
 default['metric_maker']['ruby_pkg_install_retries'] = 3
+default['metric_maker']['keep_output'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@onica.com'
 license  'Apache-2.0'
 description 'AWS CloudWatch custom metrics made easy'
 long_description 'Use for generating AWS CloudWatch metrics such as disk space, counters, and more'
-version '0.6.14'
+version '0.6.15'
 source_url 'https://github.com/tonyfruzza/metric_maker'
 issues_url 'https://github.com/tonyfruzza/metric_maker/issues'
 chef_version '>= 12.9' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@onica.com'
 license  'Apache-2.0'
 description 'AWS CloudWatch custom metrics made easy'
 long_description 'Use for generating AWS CloudWatch metrics such as disk space, counters, and more'
-version '0.6.16'
+version '0.6.17'
 source_url 'https://github.com/tonyfruzza/metric_maker'
 issues_url 'https://github.com/tonyfruzza/metric_maker/issues'
 chef_version '>= 12.9' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@onica.com'
 license  'Apache-2.0'
 description 'AWS CloudWatch custom metrics made easy'
 long_description 'Use for generating AWS CloudWatch metrics such as disk space, counters, and more'
-version '0.6.15'
+version '0.6.16'
 source_url 'https://github.com/tonyfruzza/metric_maker'
 issues_url 'https://github.com/tonyfruzza/metric_maker/issues'
 chef_version '>= 12.9' if respond_to?(:chef_version)

--- a/resources/generate.rb
+++ b/resources/generate.rb
@@ -93,7 +93,7 @@ action :install do
 
   cron 'metric_maker_run_cron' do
     minute "*/#{node['metric_maker']['interval']}"
-    command "#{node['metric_maker']['root']}/bin/metric_maker_run.rb"
+    command "#{node['metric_maker']['root']}/bin/metric_maker_run.rb #{'> /dev/null 2>&1' unless node['metric_maker']['keep_output']}"
     environment ({PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'})
     not_if {node['platform'] == 'windows'}
   end


### PR DESCRIPTION
As per your request the default action is to send output to /dev/null this behavior can be set back with an attribute override.
Already deployed to the marketplace as 0.6.17