### PR TITLE
add tunable attributes with for retry

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,3 +4,5 @@ default['metric_maker']['interval'] = 1
 default['metric_maker']['ruby_pkg_install_retries'] = 3
 default['metric_maker']['keep_output'] = false
 default['metric_maker']['cron']['enabled'] = true
+default['metric_maker']['retries'] = 20
+default['metric_maker']['sleep_seconds_between_retries'] = 5

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@onica.com'
 license  'Apache-2.0'
 description 'AWS CloudWatch custom metrics made easy'
 long_description 'Use for generating AWS CloudWatch metrics such as disk space, counters, and more'
-version '0.7.2'
+version '0.8.0'
 source_url 'https://github.com/tonyfruzza/metric_maker'
 issues_url 'https://github.com/tonyfruzza/metric_maker/issues'
 chef_version '>= 12.9' if respond_to?(:chef_version)

--- a/templates/default/metric_maker_run.rb.erb
+++ b/templates/default/metric_maker_run.rb.erb
@@ -11,7 +11,11 @@ MAX_METRIC_PER_API_CALL=20
 
 class MetricMaker
   def initialize
-    @cwm = Aws::CloudWatch::Client.new(region: get_region)
+    @cwm = Aws::CloudWatch::Client.new(
+      region: get_region,
+      retry_limit: <%= node['metric_maker']['retries'] %>,
+      retry_backoff: lambda{|c| sleep(<%= node['metric_maker']['sleep_seconds_between_retries'] %>)}
+    )
   end
 
   def get_region

--- a/templates/windows/metric_maker_run.rb.erb
+++ b/templates/windows/metric_maker_run.rb.erb
@@ -11,7 +11,11 @@ REGION_OVERRIDE='<%= node['metric_maker']['region_override'] %>'
 
 class MetricMaker
   def initialize
-    @cwm = Aws::CloudWatch::Client.new(region: get_region)
+    @cwm = Aws::CloudWatch::Client.new(
+      region: get_region,
+      retry_limit: <%= node['metric_maker']['retries'] %>,
+      retry_backoff: lambda{|c| sleep(<%= node['metric_maker']['sleep_seconds_between_retries'] %>)}
+    )
   end
 
   def get_region


### PR DESCRIPTION
Based on logic provided here: https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/timeout-duration.html setting retry to 12 with 5 second delay by default, can be alerted through attributes.rb
Releasing this at 0.8 since we've added a new _feature_ here.