### PR TITLE
Add provides :[resource_name] for chef 16.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@onica.com'
 license  'Apache-2.0'
 description 'AWS CloudWatch custom metrics made easy'
 long_description 'Use for generating AWS CloudWatch metrics such as disk space, counters, and more'
-version '0.8.0'
+version '0.8.1'
 source_url 'https://github.com/tonyfruzza/metric_maker'
 issues_url 'https://github.com/tonyfruzza/metric_maker/issues'
 chef_version '>= 12.9' if respond_to?(:chef_version)

--- a/resources/cpu.rb
+++ b/resources/cpu.rb
@@ -1,4 +1,5 @@
 resource_name :metric_maker_cpu
+provides :metric_maker_cpu
 property :metric_name, String, name_property: true
 property :namespace, String, default: 'MetricMaker'
 property :dimensions, Array, default: [], required: false

--- a/resources/disk.rb
+++ b/resources/disk.rb
@@ -1,4 +1,5 @@
 resource_name :metric_maker_disk
+provides :metric_maker_disk
 property :metric_name, String, name_property: true
 property :cw_namespace, String, default: 'MetricMaker'
 property :dimensions, Array, default: [], required: false

--- a/resources/free_mem.rb
+++ b/resources/free_mem.rb
@@ -1,4 +1,5 @@
 resource_name :metric_maker_free_mem
+provides :metric_maker_free_mem
 property :metric_name, String, name_property: true
 property :cw_namespace, String, default: 'MetricMaker'
 property :dimensions, Array, default: [], required: false

--- a/resources/generate.rb
+++ b/resources/generate.rb
@@ -1,4 +1,5 @@
 resource_name :metric_maker
+provides :metric_maker
 property :metric_name, String, name_property: true
 property :namespace, String, required: true
 property :dimensions, Array, default: [], required: false


### PR DESCRIPTION
[0.8.1]
Chef 16.2 changes the way that resource_name is used. Details in release notes: https://docs.chef.io/release_notes/#breaking-change-in-resources.

To provide backwards (<16.0) and forwards (>=16.0) compatibility, adds provides :resource_name to the metric_maker/resources.

Compile error: https://gist.github.com/dylanbartos/afeb5cd7ac69354674a73fb021fdf420